### PR TITLE
fix: send 404 when file not found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/l1ving/fs-over-http
 go 1.15
 
 require (
-	github.com/klauspost/compress v1.11.13 // indirect
+	github.com/klauspost/compress v1.12.1 // indirect
 	github.com/valyala/fasthttp v1.23.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/klauspost/compress v1.11.8 h1:difgzQsp5mdAz9v8lm3P/I+EpDKMU/6uTMw1y1FObuo=
 github.com/klauspost/compress v1.11.8/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13 h1:eSvu8Tmq6j2psUJqJrLcWH6K3w5Dwc+qipbaA6eVEN4=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.12.1 h1:/+xsCsk06wE38cyiqOR/o7U2fSftcH72xD+BQXmja/g=
+github.com/klauspost/compress v1.12.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.22.0 h1:OpwH5KDOJ9cS2bq8fD+KfT4IrksK0llvkHf4MZx42jQ=

--- a/main.go
+++ b/main.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/valyala/fasthttp"
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
+
+	"github.com/valyala/fasthttp"
 )
 
 var (
@@ -324,6 +326,11 @@ func HandleForbidden(ctx *fasthttp.RequestCtx) {
 
 func HandleInternalServerError(ctx *fasthttp.RequestCtx, err error) {
 	ctx.Response.SetStatusCode(fasthttp.StatusInternalServerError)
-	fmt.Fprintf(ctx, "500 %v\n", err)
-	log.Printf("- Returned 500 to %s with error %v", ctx.RemoteIP(), err)
+	if strings.Contains(err.Error(), "no such file or directory") {
+		fmt.Fprintf(ctx, "404 %v\n", err)
+		log.Printf("- Returned 404 to %s with error %v", ctx.RemoteIP(), err)
+	} else {
+		fmt.Fprintf(ctx, "500 %v\n", err)
+		log.Printf("- Returned 500 to %s with error %v", ctx.RemoteIP(), err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -327,7 +327,7 @@ func HandleForbidden(ctx *fasthttp.RequestCtx) {
 func HandleError(ctx *fasthttp.RequestCtx, err error) {
 	ctx.Response.SetStatusCode(fasthttp.StatusInternalServerError)
 	if strings.Contains(err.Error(), "no such file or directory") {
-		ctx.Error("File not found", fasthttp.StatusNotFound)
+		ctx.Error(err.Error(), fasthttp.StatusNotFound)
 		log.Printf("- Returned 404 to %s with error %v", ctx.RemoteIP(), err)
 	} else {
 		ctx.Error("Internal Server Error", fasthttp.StatusInternalServerError)


### PR DESCRIPTION
this is a really bad way to do this
checking what the error is inside the error handler *really* shouldnt be a thing (or even having error handling be its own function?)
but i dont know go, so here is a (and i cant stress this enough) really shitty solution

fixes #3 